### PR TITLE
Genitiv von Typ ist Typs nicht Typen.

### DIFF
--- a/basics/basic-types.md
+++ b/basics/basic-types.md
@@ -42,13 +42,13 @@ automatisch anhand des Ausdruck auf der rechten Seite. Zum Beispiel wird
 statisch während der Kompilierphase festgelegt werden und den Typ nachträglich nicht
 ändern können, wie für jede andere Variable mit explizitem Typ.
 
-### Eigenschaften eines Typen
+### Eigenschaften eines Typs
 
 Alle Datentypen haben die Eigenschaft `.init`, welche dem Initialwert gleicht.
 Für alle Ganzzahlen ist dies `0` und für Gleitkommazahlen ist es `nan` (vom Englischen
 "not a number"). Sowohl Ganzzahl- als auch Gleitkommatypen haben eine `.min` und
 `.max` Eigenschaft für die kleinste und größte Zahl, die der Typ darstellen kann.
-Gleitkommatypen besitzen noch weitere Eigenschaften: `nan` (der invalide Zustand),
+Gleitkommatypen besitzen noch weitere Eigenschaften: `nan` (der ungültige Zustand),
 `infinity` (unendlich), `.dig` (Anzahl der dezimalen Stellen der Präzision) und
 `.mant_dig` (Anzahl an Bits der Mantisse) und Weitere.
 


### PR DESCRIPTION
http://www.duden.de/rechtschreibung/Typ