### PR TITLE
Add "How to run locally" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,18 @@ Just click on "edit" and send us the pull request.
 
 You might also be looking for the [base repository](https://github.com/dlang-tour)
 that hosts the content.
+
+Run locally
+-----------
+
+You will need to fetch the [base repository](https://github.com/stonemaster/dlang-tour) via DUB once:
+
+```sh
+dub fetch dlang-tour
+```
+
+Now you can execute `dlang-tour` in the root directory of this repository:
+
+```sh
+dub run dlang-tour -- --lang-dir .
+```


### PR DESCRIPTION
Synced from upstream: https://github.com/dlang-tour/english/blob/master/README.md

I think translator need to be able to speak English in any case, so for me there's no huge benefit of translating the README.