### PR TITLE
Add proper link to gems/scope in basics/exceptions

### DIFF
--- a/basics/exceptions.md
+++ b/basics/exceptions.md
@@ -43,7 +43,7 @@ finally
 }
 ```
 
-Beachte: Die Verwendung eines [scope guards](https://tour.dlang.org/tour/en/gems/scope-guards) ist 
+Beachte: Die Verwendung eines [scope guards](gems/scope-guards) ist 
 in der Regel die bessere Lösung verglichen mit dem `try-finally`-Muster.
 
 ### Benutzerdefinierte Exceptions


### PR DESCRIPTION
The current absolute link on the [page](https://tour.dlang.org/tour/de/basics/exceptions) redirects to the English version.
Now that we have #53, a relative link can be used.

Fixes #42