### PR TITLE
'alias this' deprecated for classes

### DIFF
--- a/gems/subtyping.md
+++ b/gems/subtyping.md
@@ -24,8 +24,6 @@ mit neuer Funktionalität, aber ohne Mehraufwand
 (engl.: zero overhead) in Bezug auf Speicher oder
 Laufzeit. 
 
-`alias this` funktioniert auch mit Klassen!
-
 ## {SourceCode}
 
 ```d


### PR DESCRIPTION
https://dlang.org/changelog/2.103.0.html#dmd.deprecate-alias-this-for-classes